### PR TITLE
MSF-23: Hard-code the module version

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>org.bahmni.module</groupId>
         <artifactId>bahmniendtb</artifactId>
-        <version>${bahmniEndTbVersion}</version>
+        <version>2.3.4-SNAPSHOT</version>
     </parent>
 
 
     <packaging>jar</packaging>
     <artifactId>bahmniendtb-api</artifactId>
-    <version>${bahmniEndTbVersion}</version>
+    <version>2.3.4-SNAPSHOT</version>
 
     <dependencies>
 

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>org.bahmni.module</groupId>
         <artifactId>bahmniendtb</artifactId>
-        <version>${bahmniEndTbVersion}</version>
+        <version>2.3.4-SNAPSHOT</version>
     </parent>
 
     <packaging>jar</packaging>
     <artifactId>bahmniendtb-omod</artifactId>
-    <version>${bahmniEndTbVersion}</version>
+    <version>2.3.4-SNAPSHOT</version>
 
     <dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,6 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <bahmniEndTbVersion>2.3.4-SNAPSHOT</bahmniEndTbVersion>
         <openMRSVersion>2.0.3</openMRSVersion>
         <atomfeedVersion>2.5.4</atomfeedVersion>
         <emrapiVersion>1.17</emrapiVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.bahmni.module</groupId>
     <artifactId>bahmniendtb</artifactId>
-    <version>${bahmniEndTbVersion}</version>
+    <version>2.3.4-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>EndTB extension Module</name>
     <description>Modules to override features in bahmni-core by implementors</description>


### PR DESCRIPTION
Making this fix because somehow maven fails to decode the module version via properties thus fails to find it locally